### PR TITLE
Move schema generation into serializeForSigning method, add generateSchema option

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@docknetwork/crypto-wasm-ts",
-  "version": "0.28.0",
+  "version": "0.29.0",
   "description": "Typescript abstractions over Dock's Rust crypto library's WASM wrapper",
   "homepage": "https://github.com/docknetwork/crypto-wasm-ts",
   "main": "lib/index.js",


### PR DESCRIPTION
Was moved here because makes more sense than mutating in sign, allows the SDK to call that method to get the same values when gathering data to sign