### PR TITLE
Fix not signing proof + add proof to essential schema

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@docknetwork/crypto-wasm-ts",
-  "version": "0.29.0",
+  "version": "0.30.0",
   "description": "Typescript abstractions over Dock's Rust crypto library's WASM wrapper",
   "homepage": "https://github.com/docknetwork/crypto-wasm-ts",
   "main": "lib/index.js",
@@ -11,7 +11,7 @@
     "jest": "NODE_OPTIONS='--experimental-vm-modules' jest",
     "prepare": "husky install",
     "pretty": "prettier --config .prettierrc 'src/**/*.ts' --write",
-    "test": "NODE_OPTIONS='--experimental-vm-modules' jest",
+    "test": "yarn jest",
     "buildAndPublish": "yarn clean && yarn build && yarn publish"
   },
   "license": "Apache-2.0",

--- a/src/anonymous-credentials/credential-builder.ts
+++ b/src/anonymous-credentials/credential-builder.ts
@@ -179,10 +179,6 @@ export class CredentialBuilder extends Versioned {
       if (signingOpts.requireSameFieldsAsSchema) {
         throw new Error('Credential does not have the fields as schema');
       } else {
-        if (schema.encoder.defaultEncoder === undefined) {
-          throw new Error('Default encoder should be defined');
-        }
-        
         // Generate new schema
         this.schema = CredentialSchema.generateAppropriateSchema(s, schema);
         schema = this.schema as CredentialSchema;

--- a/src/anonymous-credentials/credential-builder.ts
+++ b/src/anonymous-credentials/credential-builder.ts
@@ -99,7 +99,9 @@ export class CredentialBuilder extends Versioned {
   }
 
   setTopLevelField(name: string, value: unknown) {
-    this._topLevelFields.set(name, value);
+    if (value !== undefined) {
+      this._topLevelFields.set(name, value);
+    }
   }
 
   getTopLevelField(name: string): unknown {
@@ -131,6 +133,7 @@ export class CredentialBuilder extends Versioned {
 
     const cred = this.serializeForSigning(signingOpts);
     const schema = this.schema as CredentialSchema;
+    this.setTopLevelField('proof', cred['proof']);
 
     const signed = signMessageObject(
       cred,
@@ -165,6 +168,10 @@ export class CredentialBuilder extends Versioned {
     }
     if (this._credStatus !== undefined) {
       s[STATUS_STR] = this._credStatus;
+    }
+
+    if (!s['proof']) {
+      Credential.applyProof(s);
     }
 
     let schema = this.schema as CredentialSchema;

--- a/src/anonymous-credentials/schema.ts
+++ b/src/anonymous-credentials/schema.ts
@@ -646,6 +646,14 @@ export class CredentialSchema extends Versioned {
               type: 'string'
             },
           },
+        },
+        proof: {
+          type: 'object',
+          properties: {
+            type: {
+              type: 'string'
+            },
+          },
         }
       }
     };

--- a/tests/anonymous-credentials/credential.spec.ts
+++ b/tests/anonymous-credentials/credential.spec.ts
@@ -382,7 +382,8 @@ describe('Credential signing and verification', () => {
           }
         },
         cryptoVersion: { type: 'string' },
-        credentialSchema: { type: 'string' }
+        credentialSchema: { type: 'string' },
+        proof: CredentialSchema.essential().properties.proof,
       },
       definitions: {
         encryptableString: { type: 'string' },
@@ -419,7 +420,8 @@ describe('Credential signing and verification', () => {
           }
         },
         cryptoVersion: { type: 'string' },
-        credentialSchema: { type: 'string' }
+        credentialSchema: { type: 'string' },
+        proof: CredentialSchema.essential().properties.proof,
       },
       definitions: {
         encryptableString: { type: 'string' },
@@ -466,7 +468,8 @@ describe('Credential signing and verification', () => {
           }
         },
         cryptoVersion: { type: 'string' },
-        credentialSchema: { type: 'string' }
+        credentialSchema: { type: 'string' },
+        proof: CredentialSchema.essential().properties.proof,
       },
       definitions: {
         encryptableString: { type: 'string' },
@@ -513,7 +516,8 @@ describe('Credential signing and verification', () => {
           }
         },
         cryptoVersion: { type: 'string' },
-        credentialSchema: { type: 'string' }
+        credentialSchema: { type: 'string' },
+        proof: CredentialSchema.essential().properties.proof,
       },
       definitions: {
         encryptableString: { type: 'string' },
@@ -562,6 +566,7 @@ describe('Credential signing and verification', () => {
         },
         cryptoVersion: { type: 'string' },
         credentialSchema: { type: 'string' },
+        proof: CredentialSchema.essential().properties.proof,
         issuer: {
           type: 'object',
           properties: {
@@ -649,6 +654,7 @@ describe('Credential signing and verification', () => {
         },
         cryptoVersion: { type: 'string' },
         credentialSchema: { type: 'string' },
+        proof: CredentialSchema.essential().properties.proof,
       },
       definitions: {
         encryptableString: { type: 'string' },
@@ -713,7 +719,8 @@ describe('Credential signing and verification', () => {
           }
         },
         cryptoVersion: { type: 'string' },
-        credentialSchema: { type: 'string' }
+        credentialSchema: { type: 'string' },
+        proof: CredentialSchema.essential().properties.proof,
       },
       definitions: {
         encryptableString: { type: 'string' },
@@ -758,7 +765,8 @@ describe('Credential signing and verification', () => {
           }
         },
         cryptoVersion: { type: 'string' },
-        credentialSchema: { type: 'string' }
+        credentialSchema: { type: 'string' },
+        proof: CredentialSchema.essential().properties.proof,
       },
       definitions: {
         encryptableString: { type: 'string' },
@@ -801,7 +809,8 @@ describe('Credential signing and verification', () => {
           }
         },
         cryptoVersion: { type: 'string' },
-        credentialSchema: { type: 'string' }
+        credentialSchema: { type: 'string' },
+        proof: CredentialSchema.essential().properties.proof,
       },
       definitions: {
         encryptableString: { type: 'string' },
@@ -833,6 +842,7 @@ describe('Credential signing and verification', () => {
         },
         cryptoVersion: { type: 'string' },
         credentialSchema: { type: 'string' },
+        proof: CredentialSchema.essential().properties.proof,
         '@context': {
           type: 'array',
           items: [ { type: 'string' }, { type: 'string' }, { type: 'string' } ]

--- a/tests/anonymous-credentials/schema.spec.ts
+++ b/tests/anonymous-credentials/schema.spec.ts
@@ -200,6 +200,9 @@ describe('Credential Schema', () => {
       [SUBJECT_STR]: {
         fname: { type: 'string' }
       },
+      proof: {
+        type: { type: 'string' },
+      },
     });
     expect(cs1.jsonSchema).toEqual({
       [META_SCHEMA_STR]: 'http://json-schema.org/draft-07/schema#',
@@ -213,7 +216,8 @@ describe('Credential Schema', () => {
           properties: {
             fname: { type: 'string' }
           }
-        }
+        },
+        proof: CredentialSchema.essential().properties.proof,
       }
     });
     expect(cs1.hasStatus()).toEqual(false);
@@ -586,24 +590,25 @@ describe('Credential Schema', () => {
   it('flattening', () => {
     const cs1 = new CredentialSchema(getExampleSchema(1));
     expect(cs1.flatten()).toEqual([
-      [SCHEMA_STR, `${SUBJECT_STR}.fname`, CRYPTO_VERSION_STR],
-      [{ type: 'string' }, { type: 'string' }, { type: 'string' }]
+      [SCHEMA_STR, `${SUBJECT_STR}.fname`, CRYPTO_VERSION_STR, 'proof.type'],
+      [{ type: 'string' }, { type: 'string' }, { type: 'string' }, { type: 'string' }]
     ]);
 
     const cs2 = new CredentialSchema(getExampleSchema(2));
     expect(cs2.flatten()).toEqual([
-      [SCHEMA_STR, `${SUBJECT_STR}.fname`, `${SUBJECT_STR}.score`, CRYPTO_VERSION_STR],
-      [{ type: 'string' }, { type: 'string' }, { type: 'integer', minimum: -100 }, { type: 'string' }],
+      [SCHEMA_STR, `${SUBJECT_STR}.fname`, `${SUBJECT_STR}.score`, CRYPTO_VERSION_STR, 'proof.type'],
+      [{ type: 'string' }, { type: 'string' }, { type: 'integer', minimum: -100 }, { type: 'string' }, { type: 'string' }],
     ]);
 
     const cs3 = new CredentialSchema(getExampleSchema(3));
     expect(cs3.flatten()).toEqual([
-      [SCHEMA_STR, `${SUBJECT_STR}.fname`, `${SUBJECT_STR}.long`, `${SUBJECT_STR}.score`, CRYPTO_VERSION_STR],
+      [SCHEMA_STR, `${SUBJECT_STR}.fname`, `${SUBJECT_STR}.long`, `${SUBJECT_STR}.score`, CRYPTO_VERSION_STR, 'proof.type'],
       [
         { type: 'string' },
         { type: 'string' },
         { type: 'positiveDecimalNumber', decimalPlaces: 2 },
         { type: 'integer', minimum: -100 },
+        { type: 'string' },
         { type: 'string' },
       ]
     ]);
@@ -619,6 +624,7 @@ describe('Credential Schema', () => {
         `${SUBJECT_STR}.fname`,
         `${SUBJECT_STR}.score`,
         CRYPTO_VERSION_STR,
+        'proof.type',
       ],
       [
         { type: 'string' },
@@ -628,6 +634,7 @@ describe('Credential Schema', () => {
         { type: 'string' },
         { type: 'string' },
         { type: 'integer', minimum: -100 },
+        { type: 'string' },
         { type: 'string' },
       ]
     ]);
@@ -654,6 +661,7 @@ describe('Credential Schema', () => {
         `${SUBJECT_STR}.sensitive.phone`,
         `${SUBJECT_STR}.sensitive.very.secret`,
         CRYPTO_VERSION_STR,
+        'proof.type',
       ],
       [
         { type: 'string' },
@@ -671,6 +679,7 @@ describe('Credential Schema', () => {
         { type: 'string' },
         { type: 'positiveInteger' },
         { compress: false, type: 'stringReversible' },
+        { type: 'string' },
         { type: 'string' },
         { type: 'string' },
         { type: 'string' },
@@ -755,7 +764,8 @@ describe('Credential Schema', () => {
         `${SUBJECT_STR}.2.location.geo.long`,
         `${SUBJECT_STR}.2.location.name`,
         `${SUBJECT_STR}.2.name`,
-        CRYPTO_VERSION_STR
+        CRYPTO_VERSION_STR,
+        'proof.type',
       ],
       [
         { type: 'string' },
@@ -769,6 +779,7 @@ describe('Credential Schema', () => {
         { type: 'string' },
         { type: 'decimalNumber', decimalPlaces: 3, minimum: -90 },
         { type: 'decimalNumber', decimalPlaces: 3, minimum: -180 },
+        { type: 'string' },
         { type: 'string' },
         { type: 'string' },
         { type: 'string' }
@@ -804,7 +815,8 @@ describe('Credential Schema', () => {
         'issuanceDate',
         'issuer.desc',
         'issuer.logo',
-        'issuer.name'
+        'issuer.name',
+        'proof.type'
       ],
       [
         { type: 'string' },
@@ -825,7 +837,8 @@ describe('Credential Schema', () => {
         { type: 'positiveInteger' },
         { type: 'string' },
         { type: 'string' },
-        { type: 'string' }
+        { type: 'string' },
+        { type: 'string' },
       ]
     ]);
   });
@@ -852,7 +865,9 @@ describe('Credential Schema', () => {
       secret: 'dk:secret',
       timeOfBirth: 'dk:timeOfBirth',
       userId: 'dk:userId',
-      weight: 'dk:weight'
+      weight: 'dk:weight',
+      proof: 'dk:proof',
+      type: 'dk:type',
     });
 
     const schema5 = getExampleSchema(5);
@@ -886,7 +901,8 @@ describe('Credential Schema', () => {
       phone: 'dk:phone',
       type: 'dk:type',
       very: 'dk:very',
-      secret: 'dk:secret'
+      secret: 'dk:secret',
+      proof: 'dk:proof',
     });
 
     const schema7 = getExampleSchema(7);
@@ -911,6 +927,8 @@ describe('Credential Schema', () => {
       issuer: 'dk:issuer',
       desc: 'dk:desc',
       logo: 'dk:logo',
+      proof: 'dk:proof',
+      type: 'dk:type',
     });
   });
 


### PR DESCRIPTION
The proof object was only being applied in toJSON which meant it wasnt being signed, especially noticeable with SDK credentials