### PR TITLE
Boolean value support

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@docknetwork/crypto-wasm-ts",
-  "version": "0.37.0",
+  "version": "0.38.0",
   "description": "Typescript abstractions over Dock's Rust crypto library's WASM wrapper",
   "homepage": "https://github.com/docknetwork/crypto-wasm-ts",
   "main": "lib/index.js",

--- a/src/anonymous-credentials/schema.ts
+++ b/src/anonymous-credentials/schema.ts
@@ -982,7 +982,7 @@ export class CredentialSchema extends Versioned {
     return min >= 0 ? { type: this.POSITIVE_INT_TYPE } : { type: this.INT_TYPE, minimum: min };
   }
 
-  static parseBooleanType(): object {
+  static parseBooleanType(node: object, parsingOpts: ISchemaParsingOpts, nodeName: string): object {
     return { type: this.BOOLEAN_TYPE };
   }
 

--- a/src/anonymous-credentials/schema.ts
+++ b/src/anonymous-credentials/schema.ts
@@ -982,7 +982,7 @@ export class CredentialSchema extends Versioned {
     return min >= 0 ? { type: this.POSITIVE_INT_TYPE } : { type: this.INT_TYPE, minimum: min };
   }
 
-  static parseBooleanType(node: { minimum?: number }, parsingOpts: ISchemaParsingOpts, nodeName: string): object {
+  static parseBooleanType(): object {
     return { type: this.BOOLEAN_TYPE };
   }
 
@@ -1055,33 +1055,41 @@ export class CredentialSchema extends Versioned {
   private static getSubschema(value: CredVal): object {
     const typ = CredentialSchema.getType(value);
 
+    if (typ === 'boolean') {
+      return { type: typ };
+    }
+
     if (typ === 'string') {
       return { type: typ };
-    } else if (typ === 'number') {
+    }
+
+    if (typ === 'number') {
       return {
         type: typ,
         minimum: DefaultSchemaParsingOpts.defaultMinimumInteger,
         multipleOf: 1 / Math.pow(10, value.toString().split('.')[1].length)
       };
-    } else if (typ === 'integer') {
+    }
+
+    if (typ === 'integer') {
       return { type: typ, minimum: DefaultSchemaParsingOpts.defaultMinimumInteger };
-    } else if (typ === 'object') {
+    }
+    
+    if (typ === 'object') {
       const obj = { type: typ, properties: {} };
       for (const [k, v] of Object.entries(value)) {
         obj.properties[k] = CredentialSchema.getSubschema(v);
       }
       return obj;
-    } else if (typ === 'boolean') {
-      return { type: typ };
-    } else {
-      // `typ` is array
-      const items: object[] = [];
-      // @ts-ignore
-      value.forEach((v) => {
-        items.push(CredentialSchema.getSubschema(v));
-      });
-      return { type: typ, items };
     }
+
+    // `typ` is array
+    const items: object[] = [];
+    // @ts-ignore
+    value.forEach((v) => {
+      items.push(CredentialSchema.getSubschema(v));
+    });
+    return { type: typ, items };
   }
 
   /**

--- a/src/encoder.ts
+++ b/src/encoder.ts
@@ -211,6 +211,18 @@ export class Encoder {
   }
 
   /**
+   * Returns an encoding function to be used on a message that is a boolean, encoded as positive int (0 or 1)
+   */
+  static booleanEncoder(): EncodeFunc {
+    return (v: unknown) => {
+      if (typeof v !== 'boolean') {
+        throw new Error(`Expected boolean but ${v} has type ${typeof v}`);
+      }
+      return MessageEncoder.encodePositiveNumberForSigning(v ? 1 : 0);
+    };
+  }
+
+  /**
    * Returns a function that can convert any input integer to a positive integer when its minimum
    * negative value is known. Does that by adding an offset of abs(minimum) to the input
    * @param minimum

--- a/tests/anonymous-credentials/credential.spec.ts
+++ b/tests/anonymous-credentials/credential.spec.ts
@@ -169,6 +169,9 @@ describe(`${Scheme} Credential signing and verification`, () => {
     builder.subject = { fname: 'John', isnotbool: true };
     expect(() => builder.sign(sk)).toThrow();
 
+    builder.subject = { fname: 'John', isbool: "not a bool" };
+    expect(() => builder.sign(sk)).toThrow();
+
     builder.subject = { fname: 'John', isbool: true };
     const cred = builder.sign(sk);
 

--- a/tests/anonymous-credentials/presentation.spec.ts
+++ b/tests/anonymous-credentials/presentation.spec.ts
@@ -170,6 +170,7 @@ describe(`${Scheme} Presentation creation and verification`, () => {
     builder2.subject = {
       fname: 'John',
       lname: 'Smith',
+      isbool: true,
       sensitive: {
         secret: 'my-secret-that-wont-tell-anyone',
         email: 'john.smith@example.com',

--- a/tests/anonymous-credentials/schema.spec.ts
+++ b/tests/anonymous-credentials/schema.spec.ts
@@ -80,6 +80,7 @@ describe('Credential Schema', () => {
           properties: {
             SSN: { $ref: '#/definitions/encryptableString' },
             userId: { $ref: '#/definitions/encryptableCompString' },
+            bool: {type: 'boolean'},
             vision: { type: 'integer', minimum: -20 },
             longitude: { type: 'number', minimum: -180, multipleOf: 0.001 },
             time: { type: 'integer', minimum: 0 },
@@ -93,6 +94,7 @@ describe('Credential Schema', () => {
       credentialSubject: {
         SSN: { type: 'stringReversible', compress: false },
         userId: { type: 'stringReversible', compress: true },
+        bool: { type: 'boolean' },
         vision: { type: 'integer', minimum: -20 },
         longitude: { type: 'decimalNumber', minimum: -180, decimalPlaces: 3 },
         time: { type: 'positiveInteger' },
@@ -257,6 +259,29 @@ describe('Credential Schema', () => {
       useDefaults: true,
       defaultMinimumInteger: -50,
       defaultDecimalPlaces: DefaultSchemaParsingOpts.defaultDecimalPlaces
+    });
+  });
+
+  it('validation of boolean type', () => {
+    const schema2 = CredentialSchema.essential();
+    schema2.properties[SUBJECT_STR] = {
+      type: 'object',
+      properties: {
+        fname: { type: 'string' },
+        isbool: { type: 'boolean' }
+      }
+    };
+    const cs = new CredentialSchema(schema2, {useDefaults: true});
+    expect(cs.schema[SUBJECT_STR]).toEqual({
+      fname: { type: 'string' },
+      isbool: { type: 'boolean' },
+    });
+    expect(cs.jsonSchema.properties[SUBJECT_STR]).toEqual({
+      type: 'object',
+      properties: {
+        fname: { type: 'string' },
+        isbool: { type: 'boolean' },
+      }
     });
   });
 

--- a/tests/anonymous-credentials/utils.ts
+++ b/tests/anonymous-credentials/utils.ts
@@ -275,6 +275,7 @@ export function getExampleSchema(num): IJsonSchema {
         properties: {
           fname: { type: 'string' },
           lname: { type: 'string' },
+          isbool: { type: 'boolean' },
           sensitive: {
             type: 'object',
             properties: {
@@ -385,6 +386,17 @@ export function getExampleBuilder(num): CredentialBuilder {
     },
     { useDefaults: true }
   );
+
+
+  const schema3 = CredentialSchema.essential();
+  schema.properties[SUBJECT_STR] = {
+    type: 'object',
+    properties: {
+      fname: { type: 'string' },
+      isbool: { type: 'boolean' }
+    }
+  };
+  const credSchema3 = new CredentialSchema(schema3, {useDefaults: true});
 
   const builder = new CredentialBuilder();
   switch (num) {
@@ -498,6 +510,10 @@ export function getExampleBuilder(num): CredentialBuilder {
       for (const k of ['@context', 'id', 'type', 'identifier', 'name', 'description']) {
         builder.setTopLevelField(k, unsignedCred[k]);
       }
+      break;
+    case 11:
+      builder.schema = credSchema3;
+      builder.subject = { fname: 'John', isbool: true };
       break;
     default:
       throw new Error(`Cannot find builder number ${num}`);


### PR DESCRIPTION
Support for boolean values and boolean type in schema generation, encoded as positive integers. @lovesh let me know if i missed any area to test with this, or if there's a more appropriate encoder function.

Without boolean type support some credentials generate the schema with a boolean type as "string", which then fails schema validation on verification and ideally bools shouldn't be encoded as strings.