### PR TITLE
docs: adds small improvements to the accumulators section in documentation

### DIFF
--- a/src/accumulator/index.ts
+++ b/src/accumulator/index.ts
@@ -6,6 +6,7 @@ export * from './IAccumulatorState';
 export * from './IInitialElementsStore';
 export * from './kb-universal-accumulator';
 export * from './kb-acccumulator-witness';
+export * from './in-memory-persistence';
 export {
   VBWitnessUpdateInfo,
   KBUniversalMembershipWitnessUpdateInfo,


### PR DESCRIPTION
Hello, as I was following through the documentation on the accumulator section, some things were confusing a little bit so I update them here. 

But one big problem was when I couldn't import `InMemoryState` from the library. Looking at the code, I found that it was not exported, so I fix this in the second commit in this PR by adding the line:
```ts
export * from './in-memory-persistence';
```